### PR TITLE
Added missing default return value for IsGCRich function

### DIFF
--- a/alignments.hpp
+++ b/alignments.hpp
@@ -484,6 +484,7 @@ public:
 		}
 		if ( gcCnt >= threshold * b->core.l_qseq )
 			return true ;
+        return false;
 	}
 
 	void GetGeneralInfo( bool stopEarly = false )


### PR DESCRIPTION
This addresses what is presumably an overlooked default return for a bool function not being specified. Please correct me if this is not the case!