### PR TITLE
Specifying char as signed to ensure compatibility with ARM architecture

### DIFF
--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -46,7 +46,7 @@ struct _junction
 char line[LINE_SIZE] ;
 char col[11][LINE_SIZE] ; // The option fields is not needed.
 char strand ; // Extract XS field
-char noncanonStrandInfo ;
+signed char noncanonStrandInfo ;
 //bool secondary ;
 int NH ;
 int editDistance ;


### PR DESCRIPTION
When non-paired end reads are used as input on ARM architectures, 'junc' fails to output correct junction information. This is because ARM 'char' usually defaults to unsigned, whereas on x86 the default is signed char. Therefore, the noncanonStrandInfo global variable cannot be set to -1 as expected on ARM CPUs (such as new macbooks), and will simply wrap around to 255.

Clearly this change will have little impact for those running PsiCLASS on a HPC node or similar, but it makes local dev a bit easier :)

Before fix:

```
mbeavitt@michael-macbookair:~/Code/C/PsiCLASS$ ./junc example/l1.bam -a
chr01 253586 259845 0 ? 0 0 0 0 
chr01 253740 253818 0 ? 0 0 0 0 
chr01 254110 254339 0 ? 0 0 0 0 
```

After fix:

```
mbeavitt@michael-macbookair:~/Code/C/PsiCLASS$ ./junc example/l1.bam -a
chr01 253586 259845 1 ? 1 0 7 0 
chr01 253740 253818 1 ? 1 0 8 0 
chr01 254110 254339 1 ? 1 0 31 0
```

Additionally, the md5 hash of psiclass_vote.gtf on both x86 and ARM architectures after ./psiclass -b example/l1.bam is identical.

fixes https://github.com/mbeavitt/PsiCLASS/issues/7